### PR TITLE
Replace unlzw with ncompress

### DIFF
--- a/mosparse/mavreader.py
+++ b/mosparse/mavreader.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import re
 import zlib
 
-from unlzw import unlzw
+from ncompress import decompress as unlzw
 
 class MavReader:
     ''' Opens AVNMAV file and returns stream of data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-unlzw
+ncompress


### PR DESCRIPTION
Hi!
This small PR replaces the `unlzw` dependency with [ncompress](https://github.com/valgur/ncompress). `unlzw` has not had a release since Python 3.6 and the current version [is leaking memory](https://github.com/ionelmc/python-unlzw/pull/3).